### PR TITLE
feat: componente SectionTitle (pasta e arquivo) (#79)

### DIFF
--- a/lp-code/package-lock.json
+++ b/lp-code/package-lock.json
@@ -4498,6 +4498,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/tailwind-merge": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/tailwind-merge/-/tailwind-merge-3.6.0.tgz",
+      "integrity": "sha512-uxL7qAVQriqRQPAyK3pj66VqskWqoZ37PW94jwOTwNfq/z9oyu1V+eqrZqtR2+fCiXdYOZe/Modt8GtvqNzu+w==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/dcastil"
+      }
+    },
     "node_modules/tailwindcss": {
       "version": "4.1.18",
       "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.1.18.tgz",

--- a/lp-code/src/components/Section/SectionTitle/SectionTitle.jsx
+++ b/lp-code/src/components/Section/SectionTitle/SectionTitle.jsx
@@ -1,0 +1,23 @@
+export default function SectionTitle({ title, subtitle }) {
+  return (
+    <header className="flex flex-col gap-4 mb-10 md:mb-14">
+      
+      {/* Wrapper preparado para a animação do título principal */}
+      <div className="title-animation-wrapper overflow-hidden">
+        <h2 className="text-3xl font-bold text-gray-800">
+          {title}
+        </h2>
+      </div>
+
+      {/* Renderização Condicional: O subtítulo só é injetado no HTML se a prop for enviada */}
+      {subtitle && (
+        <div className="subtitle-animation-wrapper overflow-hidden">
+          <p className="text-gray-600 leading-relaxed">
+            {subtitle}
+          </p>
+        </div>
+      )}
+
+    </header>
+  );
+}


### PR DESCRIPTION
📄 Resumo das Mudanças
Este PR resolve a Issue #79 com a criação do componente reutilizável `<SectionTitle />`. Ele foi desenvolvido para padronizar os cabeçalhos das seções, mantendo a consistência visual estrutural com os arquivos já existentes no projeto.

🛠️ Detalhes Técnicos & Impacto

1. Estruturação do Componente (`/components/Section/SectionTitle`)
* Criação do componente recebendo as props `{ title, subtitle }`.
* Implementação de renderização condicional para o subtítulo (`{subtitle && ...}`), garantindo que ele seja estritamente opcional conforme o escopo da issue.

2. Preparação para Animação
* Adição de `divs` atuando como wrappers em volta das tags de texto.
* Aplicação da classe `overflow-hidden` nativa do Tailwind, deixando o DOM já engatilhado para receber as animações de entrada (Reveal) no futuro sem quebrar o layout.

3. Estilização Estrita
* O componente herda exatamente as mesmas classes tipográficas utilizadas nas seções base (ex: `text-3xl font-bold text-gray-800` para títulos e `text-gray-600 leading-relaxed` para parágrafos), evitando conflitos visuais.

🧪 Como Validar (Passo a Passo)
Para validar estas alterações, siga os passos abaixo:

1. Execução: Atualize sua branch local e inicie o servidor com `npm run dev`.
2. Teste de Inserção: Em qualquer arquivo de seção (ex: `features.jsx`), importe o componente e adicione a tag `<SectionTitle title="Teste de Título" />`.
3. Teste de Prop Opcional: Renderize o componente apenas com o título e verifique no DevTools se a tag do subtítulo foi ignorada pelo DOM (não deve existir uma tag vazia renderizada).
4. Adicione a prop `subtitle="Teste de subtítulo"` e valide se o texto aparece corretamente renderizado abaixo do título, com o gap correspondente.

Closes #79