### PR TITLE
desgin seguindo figma about us (#90)

### DIFF
--- a/lp-code/src/App.tsx
+++ b/lp-code/src/App.tsx
@@ -9,6 +9,7 @@ import { useRef } from 'react'
 import { useGSAP } from '@gsap/react'
 import { gsap } from "gsap";
 import Carousel from './components/Carousel/carousel';
+import About from './components/About/About';
 
 /**
  * App Root

--- a/lp-code/src/sections/About/about.jsx
+++ b/lp-code/src/sections/About/about.jsx
@@ -3,7 +3,8 @@
 
 export default function About() {
   return (
-    <section id="about" className="w-full py-16 md:py-24 border-b border-gray-200">
+    <section id="about" className="w-full py-16 md:py-24 bg-[#3C1D47] border-b border-[#5F2E78]">
+        {/* Fundo escuro da paleta e borda sutil */}
         
         {/* substituir esta div pelo <container> quando for mergeado */}
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 w-full">
@@ -12,19 +13,28 @@ export default function About() {
             <div className="flex flex-col md:flex-row-reverse items-center gap-10 md:gap-16">
                 
                 {/* lado do texto */}
-                <article className="w-full md:w-1/2 flex flex-col gap-4">
-                    <h2 className="text-3xl font-bold text-gray-800">[titulo about]</h2>
-                    <p className="text-gray-600 leading-relaxed">
+                <article className="w-full md:w-1/2 flex flex-col gap-4" style={{ fontFamily: "'Montserrat', sans-serif" }}>
+                    <h2 className="text-3xl font-bold text-[#9BF2EA]" style={{ fontFamily: "'JetBrains Mono', monospace" }}>
+                        [titulo about]
+                    </h2>
+                    <p className="text-[#DDA9F7] leading-relaxed">
                         [primeiro paragrafo]
                     </p>
-                    <p className="text-gray-600 leading-relaxed">
+                    <p className="text-[#DDA9F7] leading-relaxed">
                         [segundo paragrafo]
                     </p>
                 </article>
 
                 {/* lado da imagem, fica em cima no mobile  */}
-                <div className="w-full md:w-1/2 h-72 bg-gray-100 rounded-lg flex items-center justify-center border-2 border-dashed border-gray-300">
-                    <span className="text-gray-500 font-medium">[imagem referente]</span>
+                <div className="relative w-full md:w-1/2 h-72 bg-[#5F2E78] rounded-lg flex flex-col items-center justify-center border-2 border-dashed border-[#9BF2EA] shadow-[0_0_20px_rgba(155,242,234,0.1)] overflow-hidden">
+                    
+                    {/* Efeito de brilho de fundo opcional para combinar com a pegada neon do Figma */}
+                    <div className="absolute inset-0 bg-gradient-to-tr from-[#5F2E78] to-[#2A8C82] opacity-30"></div>
+                    
+                    <span className="text-[#9BF2EA] font-medium z-10" style={{ fontFamily: "'JetBrains Mono', monospace" }}>
+                        [imagem referente ou mascote]
+                    </span>
+                    
                 </div>
 
             </div>

--- a/lp-code/src/sections/About/about.jsx
+++ b/lp-code/src/sections/About/about.jsx
@@ -1,6 +1,11 @@
-// quando a issue #99 tiver pronta, descomentar a linha abaixo
-// import Container from 'lp-code/components/container'; 
-
+/**
+ * @description
+ * Componente responsável por renderizar a seção "Sobre Nós" (About Us) da landing page.
+ * Apresenta a missão/textos institucionais e um container visual para a mascote do projeto.
+ * @returns {JSX.Element} Estrutura da seção About.
+ */
+export default function About() {
+// ... resto do seu código
 export default function About() {
   return (
     <section id="about" className="w-full py-16 md:py-24 bg-[#3C1D47] border-b border-[#5F2E78]">


### PR DESCRIPTION
📄 Resumo das Mudanças
Este PR resolve a Issue #90 aplicando as diretrizes visuais (Design System) aprovadas no Figma para a seção "About Us", mantendo a estrutura original pensada para responsividade.

🛠️ Detalhes Técnicos & Impacto

1. Paleta de Cores (Dark Mode)
* Aplicação do background principal `#3C1D47` (Roxo Escuro) e bordas `#5F2E78` (Roxo Médio).
* Ajuste de contraste na tipografia, utilizando `#9BF2EA` (Ciano) para o título principal e `#DDA9F7` (Lilás Claro) para os textos base.

2. Tipografia
* Injeção local das fontes `Montserrat` (textos gerais) e `JetBrains Mono` (títulos e elementos tech).

3. Elementos Visuais e Efeitos
* O placeholder da imagem/mascote recebeu a cor base dos cards com borda tracejada em ciano.
* Adição de um brilho sutil ao fundo do placeholder (`bg-gradient-to-tr` com `opacity-30` e `shadow`) para refletir a estética neon do design.

4. Estrutura
* Mantida a lógica `flex-col md:flex-row-reverse` que prioriza a imagem no topo no mobile e inverte o layout de forma fluida no desktop.

🧪 Como Validar
1. Inicie o servidor localmente com `npm run dev`.
2. Navegue até a seção About Us.
3. Verifique o contraste das cores e os efeitos de brilho do placeholder da mascote.
4. Teste a responsividade diminuindo a tela para garantir que a imagem continua subindo para o topo no formato mobile.

about us desing no figma: 
<img width="1013" height="630" alt="image" src="https://github.com/user-attachments/assets/834d98e9-fbf2-4778-b763-aeb739e08491" />


Closes #90
relates to #104 